### PR TITLE
CE-541 Tweak ruby-lint testing

### DIFF
--- a/ruby-lint.yml
+++ b/ruby-lint.yml
@@ -1,0 +1,11 @@
+---
+presenter: syntastic
+
+analysis_classes:
+  - argument_amount
+  - loop_keywords
+  - pedantics
+  - shadowing_variables
+  - undefined_variables
+  - unused_variables
+  - useless_equality_checks

--- a/setup.sh
+++ b/setup.sh
@@ -19,4 +19,4 @@ apt-get update -y
 apt-get install -y ruby2.1 rubygems
 apt-get autoremove -y
 gem install bundler
-bundle install
+bundle install --without test

--- a/test.sh
+++ b/test.sh
@@ -24,16 +24,24 @@ for GEM in ruby-lint; do
   fi
 done
 
-# Lint the Serverspec files
+# Lint the Serverspec file
 printf "***\nChecking Serverspec...\n***\n"
-ruby-lint --presenter=syntastic spec/
-if [ $? -ne 0 ]; then
+for SPEC in $(find spec -name *_spec.rb)
+do
+  echo "Checking $SPEC"
+  # Settings come from ruby-lint.yml
+  ruby-lint $SPEC
+  if [ $? -ne 0 ]; then
+    RET_SUCCESS=1
+  fi
+done
+
+if [ $RET_SUCCESS -ne 0 ]; then
   printf "***\nSERVERSPEC CHECKS FAILED\n***\n"
-  RET_SUCCESS=1
 fi
 
 # If the caller is ignoring failures, make sure we always return successfully
-if [ $IGNORE_FAILURES -eq 1 ]; then
+if [[ $IGNORE_FAILURES -eq 1 && $RET_SUCCESS -ne 0 ]]; then
   printf "***\nIgnoring failures\n***\n"
   RET_SUCCESS=0
 fi

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,7 @@ for GEM in ruby-lint; do
   fi
 done
 
-# Lint the Serverspec file
+# Lint the Serverspec files
 printf "***\nChecking Serverspec...\n***\n"
 for SPEC in $(find spec -name *_spec.rb)
 do


### PR DESCRIPTION
I'm not convinced that invoking ruby-lint was doing what we wanted, so I've
tweaked how it's invoked (once per. file in a loop).
Moved the settings out to ruby-lint.yml and disabled checks for
undefined_methods as it was triggering on all of the Serverspec DSL; there's
no definition for Serverspec in ruby-lint so that's the best we can do.