### PR TITLE
CE-426 ServerSpec tests for 2lt22s

### DIFF
--- a/spec/ospfunnum/bridges_spec.rb
+++ b/spec/ospfunnum/bridges_spec.rb
@@ -5,9 +5,13 @@ require 'json'
 if leaf?
   node_data = JSON.parse(File.read(File.expand_path('../data/bridges.json',__FILE__)))
 
+  # Select the data that's specific to this node
+  target_data = node_data[target]
+  bridges = target_data[topology]['bridges']
+
   # Each bridge a) should exist b) should have each specified interface
   # The bridge configuration is the same on both leafs
-  node_data['bridges'].each do |br|
+  bridges.each do |br|
     describe bridge(br['name']) do
       it { should exist }
     end

--- a/spec/ospfunnum/data/bridges.json
+++ b/spec/ospfunnum/data/bridges.json
@@ -1,22 +1,74 @@
 {
-  "bridges": [
-    {
-      "name": "br0",
-      "interfaces": [
-        "swp30",
-        "swp31",
-        "swp32",
-        "swp33"
+  "leaf1": {
+    "2s": {
+      "bridges": [
+        {
+          "name": "br0",
+          "interfaces": [
+            "swp30",
+            "swp31",
+            "swp32",
+            "swp33"
+          ]
+        },
+        {
+          "name": "br1",
+          "interfaces": [
+            "swp34",
+            "swp35",
+            "swp36",
+            "swp37"
+          ]
+        }
       ]
     },
-    {
-      "name": "br1",
-      "interfaces": [
-        "swp34",
-        "swp35",
-        "swp36",
-        "swp37"
+    "2lt22s": {
+      "bridges": [
+        {
+          "name": "br0",
+          "interfaces": ["swp32s0"]
+        },
+        {
+          "name": "br1",
+          "interfaces": ["swp32s1"]
+        }
       ]
     }
-  ]
+  },
+  "leaf2": {
+    "2s": {
+      "bridges": [
+        {
+          "name": "br0",
+          "interfaces": [
+            "swp30",
+            "swp31",
+            "swp32",
+            "swp33"
+          ]
+        },
+        {
+          "name": "br1",
+          "interfaces": [
+            "swp34",
+            "swp35",
+            "swp36",
+            "swp37"
+          ]
+        }
+      ]
+    },
+    "2lt22s": {
+      "bridges": [
+        {
+          "name": "br0",
+          "interfaces": ["swp32s0"]
+        },
+        {
+          "name": "br1",
+          "interfaces": ["swp32s1"]
+        }
+      ]
+    }
+  }
 }

--- a/spec/ospfunnum/data/interfaces.json
+++ b/spec/ospfunnum/data/interfaces.json
@@ -1,7 +1,8 @@
 {
   "interfaces": {
     "2s": ["lo","swp1","swp2","swp3","swp4"],
-    "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"]
+    "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+    "2lt22s": ["lo"]
   },
   "config": {
     "leaf1": {

--- a/spec/ospfunnum/data/interfaces.json
+++ b/spec/ospfunnum/data/interfaces.json
@@ -1,25 +1,38 @@
 {
-  "interfaces": {
-    "2s": ["lo","swp1","swp2","swp3","swp4"],
-    "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
-    "2lt22s": ["lo"]
+  "leaf1": {
+    "local_addr": "10.2.1.1",
+    "br0_addr": "10.4.1.1",
+    "br1_addr": "10.4.1.129",
+    "interfaces": {
+      "2s": ["lo","swp1","swp2","swp3","swp4"],
+      "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+      "2lt22s": ["lo", "swp1s0", "swp1s1", "swp1s2", "swp1s3"]
+    }
   },
-  "config": {
-    "leaf1": {
-      "local_addr": "10.2.1.1",
-      "br0_addr": "10.4.1.1",
-      "br1_addr": "10.4.1.129"
-    },
-    "leaf2": {
-      "local_addr": "10.2.1.2",
-      "br0_addr": "10.4.2.1",
-      "br1_addr": "10.4.2.129"
-    },
-    "spine1": {
-      "local_addr": "10.2.1.3"
-    },
-    "spine2": {
-      "local_addr" : "10.2.1.4"
+  "leaf2": {
+    "local_addr": "10.2.1.2",
+    "br0_addr": "10.4.2.1",
+    "br1_addr": "10.4.2.129",
+    "interfaces": {
+      "2s": ["lo","swp1","swp2","swp3","swp4"],
+      "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+      "2lt22s": ["lo", "swp1s0", "swp1s1", "swp1s2", "swp1s3"]
+    }
+  },
+  "spine1": {
+    "local_addr": "10.2.1.3",
+    "interfaces": {
+      "2s": ["lo","swp1","swp2","swp3","swp4"],
+      "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+      "2lt22s": ["lo", "swp49", "swp50", "swp51", "swp52"]
+    }
+  },
+  "spine2": {
+    "local_addr" : "10.2.1.4",
+    "interfaces": {
+      "2s": ["lo","swp1","swp2","swp3","swp4"],
+      "2s2l": ["lo","swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+      "2lt22s": ["lo", "swp49", "swp50", "swp51", "swp52"]
     }
   }
 } 

--- a/spec/ospfunnum/data/quagga.json
+++ b/spec/ospfunnum/data/quagga.json
@@ -8,6 +8,10 @@
     "2s2l": {
       "interfaces": ["swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
       "neighbors": ["10.2.1.3","10.2.1.4"]
+    },
+    "2lt22s": {
+      "interfaces": ["swp1s0", "swp1s1", "swp1s2", "swp1s3"],
+      "neighbors": ["10.2.1.3","10.2.1.4"]
     }
   },
   "leaf2": {
@@ -19,6 +23,10 @@
     "2s2l": {
       "interfaces": ["swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
       "neighbors": ["10.2.1.3","10.2.1.4"]
+    },
+    "2lt22s": {
+      "interfaces": ["swp1s0", "swp1s1", "swp1s2", "swp1s3"],
+      "neighbors": ["10.2.1.3","10.2.1.4"]
     }
   },
   "spine1": {
@@ -26,12 +34,20 @@
     "2s2l": {
       "interfaces": ["swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
       "neighbors": ["10.2.1.1","10.2.1.2"]
+    },
+    "2lt22s": {
+      "interfaces": ["swp49", "swp50", "swp51", "swp52"],
+      "neighbors": ["10.2.1.1","10.2.1.2"]
     }
   },
   "spine2": {
     "local_addr": "10.2.1.4",
     "2s2l": {
       "interfaces": ["swp1","swp2","swp3","swp4","swp17","swp18","swp19","swp20"],
+      "neighbors": ["10.2.1.1","10.2.1.2"]
+    },
+    "2lt22s": {
+      "interfaces": ["swp49", "swp50", "swp51", "swp52"],
       "neighbors": ["10.2.1.1","10.2.1.2"]
     }
   }

--- a/spec/ospfunnum/interfaces_spec.rb
+++ b/spec/ospfunnum/interfaces_spec.rb
@@ -4,10 +4,10 @@ require 'json'
 node_data = JSON.parse(File.read(File.expand_path('../data/interfaces.json',__FILE__)))
 
 # Select the data that's specific to this node
-target_data = node_data['config'][target]
+target_data = node_data[target]
 
 # ospf unnumbered has same IP on a bunch of devices
-node_data['interfaces'][topology].each do |intname| 
+target_data['interfaces'][topology].each do |intname| 
   describe interface(intname) do
     it { should have_ipv4_address("#{target_data['local_addr']}/32") }
   end

--- a/tests.json
+++ b/tests.json
@@ -18,14 +18,12 @@
     {
       "name": "ospfunnum",
       "sets": [
-        { "target": "default", "set": ["core", "quagga", "ospfunnum"] },
-        { "target": "server1", "set": ["server"] },
-        { "target": "server2", "set": ["server"] }
+        { "target": "default", "set": ["core", "quagga", "ospfunnum"] }
       ],
       "targets": {
         "2s": ["leaf1", "leaf2"],
         "2s2l": ["leaf1", "leaf2", "spine1", "spine2"],
-        "2lt22s": ["leaf1", "leaf2", "spine1", "spine2", "server1", "server2"]
+        "2lt22s": ["leaf1", "leaf2", "spine1", "spine2"]
       }
     },
     {


### PR DESCRIPTION
Make the OSPF Unnumbered tests more topology aware so that they run on 2s & 2lt22s (Mostly also on 2s2l, although the data for bridges lacks a definition for 2s2l topologies.)

Validated and tested on both a 2s and 2lt22s workbench using ospfunnum-ansible